### PR TITLE
Run tests in a Docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,8 @@
-# Python CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-python/ for more details
-#
 version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.7
+      - image: alpine
 
     working_directory: ~/repo
 
@@ -16,41 +10,13 @@ jobs:
       - checkout
       - setup_remote_docker
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
       - run:
           name: install dependencies
           command: |
-            sudo apt-get install -y firefox-esr
+            apk add --no-cache docker docker-compose git
             git clone https://github.com/GeoNode/geonode.git --depth 1
-            tag=v0.24.0
-            mkdir -p bin
-            wget https://github.com/mozilla/geckodriver/releases/download/$tag/geckodriver-$tag-linux64.tar.gz -O- | tar zx -C bin
-            wget https://download.osgeo.org/geotiff/samples/made_up/ntf_nord.tif -P data
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -r requirements.txt
 
-      - save_cache:
-          paths:
-            - ./venv
-            - ./bin
-            - ./data
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
-
-      # run tests!
-      # this example uses Django's built-in test-runner
-      # other common Python testing frameworks include pytest and nose
-      # https://pytest.org
-      # https://nose.readthedocs.io
       - run:
           name: run tests
           command: |
-            export PATH=$PATH:$(pwd)/bin
-            . venv/bin/activate
             ./test-docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.7-alpine
+
+WORKDIR /app
+ADD /test *.sh *.txt *.ini docker/cmd.sh ./
+
+RUN apk add --no-cache \
+        firefox-esr curl \
+        build-base libffi-dev openssl-dev && \
+    python3 -m venv venv && \
+    . venv/bin/activate && \
+    pip install -r requirements.txt && \
+    tag=v0.24.0 && \
+    mkdir -p bin data && \
+    wget https://github.com/mozilla/geckodriver/releases/download/$tag/geckodriver-$tag-linux64.tar.gz -O- | tar zx -C bin && \
+    wget https://download.osgeo.org/geotiff/samples/made_up/ntf_nord.tif -P data
+
+ENV GEONODE_URL=http://nginx
+CMD ["sh", "/app/cmd.sh"]

--- a/docker/cmd.sh
+++ b/docker/cmd.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -ex
+
+set -e
+
+cd /app  # needed?
+PATH=$PATH:$(pwd)/bin
+. venv/bin/activate
+for i in {1..60}; do
+    curl --fail -s -o /dev/null http://nginx && exec ./test.sh "$@"
+    sleep 10
+done
+exit 1
+

--- a/docker/compose-test.yml
+++ b/docker/compose-test.yml
@@ -1,0 +1,7 @@
+version: '3.4'
+
+services:
+  geonode-selenium:
+    image: geonode-selenium
+    build:
+      context: ..

--- a/test-core.sh
+++ b/test-core.sh
@@ -11,7 +11,7 @@ set -a
 set +a
 
 cd $(dirname "${BASH_SOURCE[0]}")
-for i in {1..3}; do
+for i in $(seq 1 3); do
     cd "$GEONODE_REPOSITORY/"
     docker-compose \
         -f docker-compose.yml \
@@ -23,7 +23,7 @@ for i in {1..3}; do
         up -d $COMPOSE_OPTS
     cd -
 
-    for i in {1..60}; do
+    for i in $(seq 1 60); do
         if docker logs --tail 10 django4geonode |& grep "getting INI configuration from /usr/src/app/uwsgi.ini"; then
             ./test.sh "$@"
             exit $?

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -1,31 +1,30 @@
-#!/bin/bash -ex
+#!/bin/sh -ex
 
 set -e
 
 set -a
-: "${HTTP_HOST:=127.0.0.1}"
-: "${HTTP_PORT:=8080}"
+HTTP_HOST=nginx
+HTTP_PORT=80
 : "${GEONODE_REPOSITORY:=geonode}"
 : "${COMPOSE_OPTS:=--build}"
 set +a
 
-cd $(dirname "${BASH_SOURCE[0]}")
-for i in {1..3}; do
-    cd "$GEONODE_REPOSITORY/scripts/spcgeonode/"
+cd $(dirname $(realpath "$0"))
+docker-compose -f docker/compose-test.yml build
+cd "$GEONODE_REPOSITORY/scripts/spcgeonode/"
+for i in $(seq 1 3); do
     checks=$(grep -r 'healthcheck:' docker-compose.yml | wc -l)
     docker-compose -f docker-compose.yml down --volumes --remove-orphans
     docker-compose -f docker-compose.yml up -d $COMPOSE_OPTS \
         django geoserver postgres nginx \
         celery celerybeat celerycam rabbitmq
-    cd -
 
-    for i in {1..60}; do
+    for j in $(seq 1 60); do
         containers=$(docker ps -q \
                      --filter label=com.docker.compose.project=spcgeonode \
                      --filter health=healthy | wc -l)
         if [[ "$containers" -eq "$checks" ]]; then
-            ./test.sh "$@"
-            exit $?
+            exec docker-compose -f $OLDPWD/docker/compose-test.yml run geonode-selenium sh cmd.sh "$@"
         fi
         sleep 10
     done

--- a/test.sh
+++ b/test.sh
@@ -1,8 +1,8 @@
-#!/bin/bash -ex
+#!/bin/sh -ex
 
 set -e
 
-cd $(dirname "${BASH_SOURCE[0]}")
+cd $(dirname $(realpath "$0"))
 
 PYTHON=python3
 if $($PYTHON -m fades -V >/dev/null); then


### PR DESCRIPTION
Tests can now be run in a container, in the same virtual network of GeoNode without exposing any port.
Scripts are now POSIX compliant (so they can be executed with Alpine, which has no Bash).
Circle CI is now working, so I would suggest to not to automatically merge pull requests if the tests are failing, because that would probably be due to a regression. Branch merging on this repository has stricter rule now (see "Settings" tab).
