### PR TITLE
[Issue GeoNode/geonode#6079] Remove celerycam

### DIFF
--- a/test-docker.sh
+++ b/test-docker.sh
@@ -17,7 +17,7 @@ for i in $(seq 1 3); do
     docker-compose -f docker-compose.yml down --volumes --remove-orphans
     docker-compose -f docker-compose.yml up -d $COMPOSE_OPTS \
         django geoserver postgres nginx \
-        celery celerybeat celerycam rabbitmq
+        celery celerybeat rabbitmq
 
     for j in $(seq 1 60); do
         containers=$(docker ps -q \


### PR DESCRIPTION
PR to resolve issues under SPCGeoNode pertaining to the now deprecated `django-celery-monitor` extension as described in GeoNode/geonode#6018 by the removal of the `celerycam` container. Django 2.2 is no longer supported as per https://github.com/jazzband/django-celery-monitor/issues/107. I found this to be a potential solution to failing tests introduced when transitioning to spatial datastores as part of [GNIP-75](https://github.com/GeoNode/geonode/issues/6079).